### PR TITLE
Fix GenerateNewConsoleApp Func

### DIFF
--- a/Strict.Compiler.Tests/SourceGeneratorTests.cs
+++ b/Strict.Compiler.Tests/SourceGeneratorTests.cs
@@ -69,9 +69,13 @@ Run
 
 	private static string GenerateNewConsoleApp(string? generatedCode)
 	{
-		File.Delete("Program.cs");
-		Process.Start("dotnet", "new console --name GenerateFileReadProgram");
-		File.WriteAllText("Program.cs", generatedCode);
+		const string FileReadProgramDirectory = "GenerateFileReadProgram";
+		if (Directory.Exists(FileReadProgramDirectory))
+			Directory.Delete(FileReadProgramDirectory, true);
+		var projectCreationProcess =
+			Process.Start("dotnet", "new console --name " + FileReadProgramDirectory);
+		projectCreationProcess.WaitForExit();
+		File.WriteAllText(FileReadProgramDirectory + "/Program.cs", generatedCode);
 		var process = new Process
 		{
 			StartInfo = new ProcessStartInfo
@@ -80,7 +84,8 @@ Run
 				Arguments = "run " + "Program.cs",
 				UseShellExecute = false,
 				RedirectStandardOutput = true,
-				RedirectStandardError = true
+				RedirectStandardError = true,
+				WorkingDirectory = FileReadProgramDirectory
 			}
 		};
 		process.Start();


### PR DESCRIPTION
Instead of deleting Program.cs now it deletes GenerateFileReadProgram directory. A little slow but at least green.